### PR TITLE
Changed branch for new translations

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,12 +65,12 @@ matrix:
     - REPO_NAME: ios-app
       REPO_URL: https://github.com/owncloud/ios-app.git
       REPO_GIT: git@github.com:owncloud/ios-app.git
-      REPO_BRANCH: master
+      REPO_BRANCH: translation-sync
 
     - REPO_NAME: ios-sdk
       REPO_URL: https://github.com/owncloud/ios-sdk.git
       REPO_GIT: git@github.com:owncloud/ios-sdk.git
-      REPO_BRANCH: master
+      REPO_BRANCH: translation-sync
 
     - REPO_NAME: ios-old
       REPO_URL: https://github.com/owncloud/ios.git


### PR DESCRIPTION
Changed branch for new translations for repo ios-app, ios-sdk to translation-sync instead of master. This will avoid to rebase and clean up the commits in the master.

Branch `translation-sync` is created in repo ios-app and ios-sdk.