### PR TITLE
New variables to have a different clone and commit branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ clone:
     tags: false
     recursive: false
     remote: ${REPO_URL}
-    ref: ${REPO_BRANCH}
+    ref: ${REPO_CLONE_BRANCH}
     sha: FETCH_HEAD
 
 pipeline:
@@ -42,7 +42,7 @@ pipeline:
     author_email: devops@owncloud.com
     remote: ${REPO_GIT}
     remote_name: upstream
-    branch: ${REPO_BRANCH}
+    branch: ${REPO_COMMIT_BRANCH}
     empty_commit: false
     commit: true
     commit_message: '[tx] updated from transifex'
@@ -55,7 +55,7 @@ pipeline:
     secrets: [ slack_webhook ]
     channel: mobile
     template: >
-      *{{build.status}}* <{{build.link}}|{{repo.owner}}/{{repo.name}}#{{truncate build.commit 8}}> <${REPO_URL}|${REPO_NAME}@${REPO_BRANCH}>
+      *{{build.status}}* <{{build.link}}|{{repo.owner}}/{{repo.name}}#{{truncate build.commit 8}}> <${REPO_URL}|${REPO_NAME}@${REPO_COMMIT_BRANCH}>
     when:
       event: [ push ]
       status: [ changed, failure ]
@@ -65,19 +65,23 @@ matrix:
     - REPO_NAME: ios-app
       REPO_URL: https://github.com/owncloud/ios-app.git
       REPO_GIT: git@github.com:owncloud/ios-app.git
-      REPO_BRANCH: translation-sync
+      REPO_CLONE_BRANCH: master
+      REPO_COMMIT_BRANCH: translation-sync
 
     - REPO_NAME: ios-sdk
       REPO_URL: https://github.com/owncloud/ios-sdk.git
       REPO_GIT: git@github.com:owncloud/ios-sdk.git
-      REPO_BRANCH: translation-sync
+      REPO_CLONE_BRANCH: master
+      REPO_COMMIT_BRANCH: translation-sync
 
     - REPO_NAME: ios-old
       REPO_URL: https://github.com/owncloud/ios.git
       REPO_GIT: git@github.com:owncloud/ios.git
-      REPO_BRANCH: master
+      REPO_CLONE_BRANCH: master
+      REPO_COMMIT_BRANCH: master
 
     - REPO_NAME: android-app
       REPO_URL: https://github.com/owncloud/android.git
       REPO_GIT: git@github.com:owncloud/android.git
-      REPO_BRANCH: master
+      REPO_CLONE_BRANCH: master
+      REPO_COMMIT_BRANCH: master


### PR DESCRIPTION
I added a new variable to use a different clone branch as source for the translation files. This will keep Transifex up-to-date with the current master and all changes from Transifex will committed into the commit branch.

- renamed REPO_BRANCH to REPO_COMMIT_BRANCH
- added new variable REPO_CLONE_BRANCH, which is used as clone source