### PR TITLE
use master branch also for owncloud/core

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -183,7 +183,7 @@ matrix:
     - REPO_NAME: core
       REPO_URL: https://github.com/owncloud/core.git
       REPO_GIT: git@github.com:owncloud/core.git
-      REPO_BRANCH: tx
+      REPO_BRANCH: master
       REPO_PATH: l10n
       MODE: MAKE
 


### PR DESCRIPTION
We currently only pushed translations to the branch `tx` - but fore owncloud/core we should also use the master branch