### PR TITLE
Remove user management app.

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -34,7 +34,6 @@ def main(ctx):
         ),
         repo(name = "twofactor_totp", mode = "old"),
         repo(name = "user_ldap", mode = "old"),
-        repo(name = "user_management", mode = "old"),
         repo(name = "encryption", mode = "old"),
         repo(name = "phoenix", mode = "make"),
         repo(


### PR DESCRIPTION
@phil-davis commenting on a failing user_management ci build:
"user_management app is no longer being maintained as a separate app
(git got split a long time ago when core master was planned to be ownCloud v11, but now that the previous core stable10 branch became core master, the user management functionality is back to being bundled inside the core code. So CI for user_management app always fails because the CI scripts/settings... have not been update for the drone CI etc changes in the last few months)
"somebody" needs to decide what to do with it long-term - get it up-to-date and then remove the core code..., or completely archive/delete the user_management app."