### PR TITLE
Enable pipelines for all branches and cronjobs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -140,7 +140,7 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
             },
 
             # translation push
-            {
+            whenPush({
                 "name": "translation-push",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
@@ -162,7 +162,7 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                     "cd '%s'" % work_dir,
                     "tx -d push -s --skip --no-interactive",
                 ],
-            },
+            }),
 
             # translation pull
             {
@@ -279,9 +279,8 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
             }),
         ],
         "trigger": {
-            "cron": ["nightly"],
             "ref": [
-                "refs/heads/master",
+                "refs/heads/**",
             ],
         },
     }
@@ -312,7 +311,9 @@ def notification(depends_on = []):
             },
         ],
         "trigger": {
-            "cron": ["nightly"],
+            "ref": [
+                "refs/heads/**",
+            ],
             "status": ["success", "failure"],
         },
     }

--- a/.drone.star
+++ b/.drone.star
@@ -115,9 +115,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-directory",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "mkdir -p '%s'" % work_dir,
                 ] if mode == "old" else ["echo 'noop'"],
@@ -128,9 +125,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-reader",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "cd '%s'" % work_dir,
                     "make l10n-read",
@@ -139,9 +133,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-reader-old",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "cd '%s'" % work_dir,
                     "l10n '" + name + "' read",
@@ -203,9 +194,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-writer",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "cd '%s'" % work_dir,
                     "make l10n-write",
@@ -214,9 +202,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-writer-old",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "cd '%s'" % work_dir,
                     "l10n '" + name + "' write",
@@ -228,9 +213,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-cleanup",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "cd '%s'" % work_dir,
                     "make l10n-clean",
@@ -239,9 +221,6 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-cleanup-old",
                 "image": "owncloudci/transifex:latest",
                 "pull": "always",
-                "environment": {
-                    "TX_TOKEN": from_secret("tx_token"),
-                },
                 "commands": [
                     "cd '%s'" % work_dir,
                     "find . -name *.po -type f -delete",


### PR DESCRIPTION
whenPush makes sure that only non-destructive steps are executed for non-master builds. This way we can have PRs built and tested without breaking anything.

Current drone behavior is really confusing. If you specify a cron trigger, you cannot have branches built. You can only limit the event to push and cron, but then we can as well just specify the ref to be refs/heads/** which is everything but pull requests.
We need the tx_token for pulling translations from transifex, without that step some pipelines fail and so we cannot enable tests for external PRs. At least for PRs from the same repo we have some testing now.