### PR TITLE
fix: unset git env variables to use plugin settings

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -244,6 +244,12 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 "name": "translation-commit",
                 "image": "plugins/git-action:latest",
                 "pull": "always",
+                "environment": {
+                    "GIT_AUTHOR_NAME": "",
+                    "GIT_AUTHOR_EMAIL": "",
+                    "GIT_COMMITTER_NAME": "",
+                    "GIT_COMMITTER_EMAIL": "",
+                },
                 "settings": {
                     "actions": "commit",
                     "author_name": "ownClouders",


### PR DESCRIPTION
Background:

- It looks like Drone exposes `GIT_*` environment variables on every single pipeline step
- Problematic variables are GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL
- As git will always use these env vars due to the higher priority, it is impossible to set a different commit author/email in plugins that uses git