### PR TITLE
switch design system to stable-14.0 branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -25,7 +25,11 @@ def main(ctx):
         repo(name = "notes", mode = "old"),
         repo(name = "notifications", mode = "old"),
         repo(name = "oauth2", mode = "old"),
-        repo(name = "owncloud-design-system", mode = "make"),
+        repo(
+            name = "owncloud-design-system",
+            branch = "stable-14.0",
+            mode = "make",
+        ),
         repo(name = "password_policy", mode = "old"),
         repo(name = "richdocuments", mode = "old"),
         repo(name = "tasks", mode = "old"),


### PR DESCRIPTION
The owncloud-design-system has been imported to the "web" repo (= translations happening in the "web" pipeline of the translation sync). Since web v6.0 (version in the oCIS 2.0.0 GA release) still uses the dependency from npmjs.com we created a stable branch in the design system repo and made that the default branch. Translations of the 14.0.x design system still need to be synced until we archive the repo in a few months.