### PR TITLE
ci: remove archived owncloud-design-system repo

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -132,8 +132,8 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 },
                 "commands": [
                     "cd '%s'" % work_dir,
-                    "npm install --silent --global --force \"$(jq -r '.packageManager' < package.json)\"",
-                    "pnpm config set store-dir ./.pnpm-store",
+                    "npm install --silent --global --force \"$(jq -r '.packageManager' < package.json)\";" +
+                    "pnpm config set store-dir ./.pnpm-store;" +
                     "pnpm install" if path == "web" else "",
                     "make l10n-read",
                 ],

--- a/.drone.star
+++ b/.drone.star
@@ -26,11 +26,6 @@ def main(ctx):
         repo(name = "notes", mode = "old"),
         repo(name = "notifications", mode = "old"),
         repo(name = "oauth2", mode = "old"),
-        repo(
-            name = "owncloud-design-system",
-            branch = "stable-14.0",
-            mode = "make",
-        ),
         repo(name = "password_policy", mode = "old"),
         repo(name = "richdocuments", mode = "old"),
         repo(name = "tasks", mode = "old"),
@@ -137,8 +132,8 @@ def repo(name, url = "", git = "", sub_path = "", branch = "master", mode = "mak
                 },
                 "commands": [
                     "cd '%s'" % work_dir,
-                    "npm install --silent --global --force \"$(jq -r '.packageManager' < package.json)\";" + \
-                    "pnpm config set store-dir ./.pnpm-store;" + \
+                    "npm install --silent --global --force \"$(jq -r '.packageManager' < package.json)\"",
+                    "pnpm config set store-dir ./.pnpm-store",
                     "pnpm install" if path == "web" else "",
                     "make l10n-read",
                 ],


### PR DESCRIPTION
Repo `owncloud-design-system` is now archived. See https://github.com/owncloud/owncloud-design-system
And drone-ci is complaining about it https://drone.owncloud.com/owncloud/translation-sync/3155/27/12

We may not want to run CI for archived repos so this PR removes archived repo. 