### PR TITLE
[full-ci] [tests-only] Changed rocketchat notifications server

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -318,7 +318,7 @@ def notification(depends_on = []):
                 "pull": "always",
                 "settings": {
                     "webhook": {
-                        "from_secret": "rocketchat_chat_webhook",
+                        "from_secret": "rocketchat_talk_webhook",
                     },
                     "channel": "builds",
                 },


### PR DESCRIPTION
This PR change the rocketchat notification server `chat` to `talk`.

Part of https://github.com/owncloud/QA/issues/846
