### PR TITLE
[full-ci]remove qnap form repo_pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -41,7 +41,6 @@ def main(ctx):
         repo(name = "user_ldap", mode = "old"),
         repo(name = "encryption", mode = "old"),
         repo(name = "ocis", mode = "make"),
-        repo(name = "qnap", mode = "make"),
         repo(name = "openidconnect", mode = "make"),
         repo(name = "web", mode = "make", package_manager = "pnpm"),
         repo(name = "web-extensions", mode = "make", branch = "main", package_manager = "pnpm"),


### PR DESCRIPTION
### Description
Removed `qnap` from repo_pipelines as `qnap` repo has been archived.

- Fixes: https://github.com/owncloud/translation-sync/issues/70