### PR TITLE
[tests-only][full-ci] Update drone CI to use dynamic repo slug in wget URL on notification

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -308,7 +308,7 @@ def notification(ctx, depends_on = []):
                     },
                 },
                 "commands": [
-                    "wget https://raw.githubusercontent.com/owncloud/ocis/%s/tests/config/drone/notification.sh" % ctx.build.commit,
+                    "wget https://raw.githubusercontent.com/%s/%s/tests/config/drone/notification.sh" % (ctx.repo.slug, ctx.build.commit),
                     "bash notification.sh",
                 ],
             },


### PR DESCRIPTION
## Description
Replaced the hardcoded repo `owncloud/ocis` in the Drone pipeline with `ctx.repo.slug`:
