### PR TITLE
Remove Ocis Stable branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -41,7 +41,6 @@ def main(ctx):
         repo(name = "user_ldap", mode = "old"),
         repo(name = "encryption", mode = "old"),
         repo(name = "ocis", mode = "make"),
-        repo(name = "ocis-stable-7.1", mode = "make", branch = "stable-7.1", url = "https://github.com/owncloud/ocis.git", git = "git@github.com:owncloud/ocis.git"),
         repo(name = "openidconnect", mode = "make"),
         repo(name = "web", mode = "make", package_manager = "pnpm"),
         repo(name = "web-extensions", mode = "make", branch = "main", package_manager = "pnpm"),


### PR DESCRIPTION
We can't sync with the stable branch as this will result in lost translation
