### PR TITLE
Remove 'tasks' repository from .drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -27,7 +27,6 @@ def main(ctx):
         repo(name = "oauth2", mode = "old"),
         repo(name = "password_policy", mode = "old"),
         repo(name = "richdocuments", mode = "old"),
-        repo(name = "tasks", mode = "old"),
         repo(name = "twofactor_backup_codes", mode = "old"),
         repo(
             name = "twofactor_privacyidea",


### PR DESCRIPTION
The [tasks](https://github.com/owncloud/tasks) repository has been archived by @DeepDiver1975 and is now write protected.

We therefore must remove the `tasks` repository from the translation-sync configuration to avoid CI errors.