### PR TITLE
ci: migrate pipeline from Drone to GitHub Actions

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -25,7 +25,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/core.git
-            git: git@github.com:owncloud/core.git
 
           - name: activity
             mode: old
@@ -33,7 +32,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/activity.git
-            git: git@github.com:owncloud/activity.git
 
           - name: announcementcenter
             mode: old
@@ -41,7 +39,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/announcementcenter.git
-            git: git@github.com:owncloud/announcementcenter.git
 
           - name: brute_force_protection
             mode: old
@@ -49,7 +46,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/brute_force_protection.git
-            git: git@github.com:owncloud/brute_force_protection.git
 
           - name: calendar
             mode: old
@@ -57,7 +53,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/calendar.git
-            git: git@github.com:owncloud/calendar.git
 
           - name: contacts
             mode: old
@@ -65,7 +60,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/contacts.git
-            git: git@github.com:owncloud/contacts.git
 
           - name: customgroups
             mode: old
@@ -73,7 +67,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/customgroups.git
-            git: git@github.com:owncloud/customgroups.git
 
           - name: diagnostics
             mode: old
@@ -81,7 +74,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/diagnostics.git
-            git: git@github.com:owncloud/diagnostics.git
 
           - name: drawio
             mode: old
@@ -89,7 +81,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/drawio.git
-            git: git@github.com:owncloud/drawio.git
 
           - name: external
             mode: old
@@ -97,7 +88,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/external.git
-            git: git@github.com:owncloud/external.git
 
           - name: files_antivirus
             mode: old
@@ -105,7 +95,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/files_antivirus.git
-            git: git@github.com:owncloud/files_antivirus.git
 
           - name: files_external_dropbox
             mode: old
@@ -113,7 +102,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/files_external_dropbox.git
-            git: git@github.com:owncloud/files_external_dropbox.git
 
           - name: files_external_ftp
             mode: old
@@ -121,7 +109,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/files_external_ftp.git
-            git: git@github.com:owncloud/files_external_ftp.git
 
           - name: files_paperhive
             mode: old
@@ -129,7 +116,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/files_paperhive.git
-            git: git@github.com:owncloud/files_paperhive.git
 
           - name: files_primary_s3
             mode: make
@@ -137,7 +123,6 @@ jobs:
             sub_path: .
             package_manager: npm
             url: https://github.com/owncloud/files_primary_s3.git
-            git: git@github.com:owncloud/files_primary_s3.git
 
           - name: files_mediaviewer
             mode: make
@@ -145,7 +130,6 @@ jobs:
             sub_path: .
             package_manager: npm
             url: https://github.com/owncloud/files_mediaviewer.git
-            git: git@github.com:owncloud/files_mediaviewer.git
 
           - name: files_texteditor
             mode: old
@@ -153,7 +137,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/files_texteditor.git
-            git: git@github.com:owncloud/files_texteditor.git
 
           - name: files_pdfviewer
             mode: make
@@ -161,7 +144,6 @@ jobs:
             sub_path: .
             package_manager: npm
             url: https://github.com/owncloud/files_pdfviewer.git
-            git: git@github.com:owncloud/files_pdfviewer.git
 
           - name: firstrunwizard
             mode: old
@@ -169,7 +151,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/firstrunwizard.git
-            git: git@github.com:owncloud/firstrunwizard.git
 
           - name: guests
             mode: old
@@ -177,7 +158,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/guests.git
-            git: git@github.com:owncloud/guests.git
 
           - name: impersonate
             mode: old
@@ -185,7 +165,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/impersonate.git
-            git: git@github.com:owncloud/impersonate.git
 
           - name: notes
             mode: old
@@ -193,7 +172,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/notes.git
-            git: git@github.com:owncloud/notes.git
 
           - name: notifications
             mode: old
@@ -201,7 +179,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/notifications.git
-            git: git@github.com:owncloud/notifications.git
 
           - name: oauth2
             mode: old
@@ -209,7 +186,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/oauth2.git
-            git: git@github.com:owncloud/oauth2.git
 
           - name: password_policy
             mode: old
@@ -217,7 +193,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/password_policy.git
-            git: git@github.com:owncloud/password_policy.git
 
           - name: richdocuments
             mode: old
@@ -225,7 +200,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/richdocuments.git
-            git: git@github.com:owncloud/richdocuments.git
 
           - name: twofactor_backup_codes
             mode: old
@@ -233,15 +207,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/twofactor_backup_codes.git
-            git: git@github.com:owncloud/twofactor_backup_codes.git
-
-          - name: twofactor_privacyidea
-            mode: old
-            branch: master
-            sub_path: twofactor_privacyidea/l10n
-            package_manager: npm
-            url: https://github.com/privacyidea/privacyidea-owncloud-app.git
-            git: git@github.com:privacyidea/privacyidea-owncloud-app.git
 
           - name: twofactor_totp
             mode: old
@@ -249,7 +214,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/twofactor_totp.git
-            git: git@github.com:owncloud/twofactor_totp.git
 
           - name: user_ldap
             mode: old
@@ -257,7 +221,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/user_ldap.git
-            git: git@github.com:owncloud/user_ldap.git
 
           - name: encryption
             mode: old
@@ -265,7 +228,6 @@ jobs:
             sub_path: l10n
             package_manager: npm
             url: https://github.com/owncloud/encryption.git
-            git: git@github.com:owncloud/encryption.git
 
           - name: ocis
             mode: make
@@ -273,7 +235,6 @@ jobs:
             sub_path: .
             package_manager: npm
             url: https://github.com/owncloud/ocis.git
-            git: git@github.com:owncloud/ocis.git
 
           - name: openidconnect
             mode: make
@@ -281,7 +242,6 @@ jobs:
             sub_path: .
             package_manager: npm
             url: https://github.com/owncloud/openidconnect.git
-            git: git@github.com:owncloud/openidconnect.git
 
           - name: web
             mode: make
@@ -289,7 +249,6 @@ jobs:
             sub_path: .
             package_manager: pnpm
             url: https://github.com/owncloud/web.git
-            git: git@github.com:owncloud/web.git
 
           - name: web-extensions
             mode: make
@@ -297,7 +256,6 @@ jobs:
             sub_path: .
             package_manager: pnpm
             url: https://github.com/owncloud/web-extensions.git
-            git: git@github.com:owncloud/web-extensions.git
 
           - name: android
             mode: native
@@ -305,14 +263,16 @@ jobs:
             sub_path: .
             package_manager: npm
             url: https://github.com/owncloud/android.git
-            git: git@github.com:owncloud/android.git
 
     steps:
       - name: Configure git
+        env:
+          GIT_PUSH_PAT: ${{ secrets.GIT_PUSH_PAT }}
         run: |
           git config --global user.name "ownClouders"
           git config --global user.email "devops@owncloud.com"
           git config --global --add safe.directory '*'
+          git config --global url."https://x-access-token:${GIT_PUSH_PAT}@github.com/".insteadOf "https://github.com/"
 
       - name: Wipe checkout
         run: rm -rf '${{ matrix.name }}'
@@ -415,21 +375,8 @@ jobs:
           cd '${{ matrix.name }}'
           git show -p
 
-      - name: Setup SSH key
-        if: github.ref == 'refs/heads/master'
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.GIT_PUSH_SSH_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-
       - name: Push translations
         if: github.ref == 'refs/heads/master'
-        env:
-          GIT_SSH_COMMAND: ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no
         run: |
           cd '${{ matrix.name }}'
-          git remote set-url origin '${{ matrix.git }}'
           git push origin '${{ matrix.branch }}'

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   sync:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -265,13 +265,6 @@ jobs:
             url: https://github.com/owncloud/android.git
 
     steps:
-      - name: Configure git
-        env:
-          GIT_PUSH_PAT: ${{ secrets.GIT_PUSH_PAT }}
-        run: |
-          git config --global --add safe.directory '*'
-          git config --global url."https://x-access-token:${GIT_PUSH_PAT}@github.com/".insteadOf "https://github.com/"
-
       - name: Wipe checkout
         run: rm -rf '${{ matrix.name }}'
 
@@ -372,3 +365,4 @@ jobs:
           commit_user_email: devops@owncloud.com
           files_pattern: ${{ matrix.name }}
           empty_commit: false
+          access_token: ${{ secrets.GIT_PUSH_PAT }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -433,18 +433,3 @@ jobs:
           cd '${{ matrix.name }}'
           git remote set-url origin '${{ matrix.git }}'
           git push origin '${{ matrix.branch }}'
-
-  notification:
-    name: notification
-    runs-on: ubuntu-latest
-    needs: sync
-    if: always() && github.ref == 'refs/heads/master' && (needs.sync.result == 'failure' || (needs.sync.result == 'success' && github.event_name == 'schedule'))
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Send Matrix notification
-        env:
-          MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
-          JOB_STATUS: ${{ needs.sync.result }}
-        run: bash config/github/notification.sh

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -24,252 +24,220 @@ jobs:
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/core.git
 
           - name: activity
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/activity.git
 
           - name: announcementcenter
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/announcementcenter.git
 
           - name: brute_force_protection
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/brute_force_protection.git
 
           - name: calendar
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/calendar.git
 
           - name: contacts
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/contacts.git
 
           - name: customgroups
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/customgroups.git
 
           - name: diagnostics
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/diagnostics.git
 
           - name: drawio
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/drawio.git
 
           - name: external
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/external.git
 
           - name: files_antivirus
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/files_antivirus.git
 
           - name: files_external_dropbox
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/files_external_dropbox.git
 
           - name: files_external_ftp
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/files_external_ftp.git
 
           - name: files_paperhive
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/files_paperhive.git
 
           - name: files_primary_s3
             mode: make
             branch: master
             sub_path: .
             package_manager: npm
-            url: https://github.com/owncloud/files_primary_s3.git
 
           - name: files_mediaviewer
             mode: make
             branch: master
             sub_path: .
             package_manager: npm
-            url: https://github.com/owncloud/files_mediaviewer.git
 
           - name: files_texteditor
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/files_texteditor.git
 
           - name: files_pdfviewer
             mode: make
             branch: master
             sub_path: .
             package_manager: npm
-            url: https://github.com/owncloud/files_pdfviewer.git
 
           - name: firstrunwizard
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/firstrunwizard.git
 
           - name: guests
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/guests.git
 
           - name: impersonate
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/impersonate.git
 
           - name: notes
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/notes.git
 
           - name: notifications
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/notifications.git
 
           - name: oauth2
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/oauth2.git
 
           - name: password_policy
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/password_policy.git
 
           - name: richdocuments
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/richdocuments.git
 
           - name: twofactor_backup_codes
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/twofactor_backup_codes.git
 
           - name: twofactor_totp
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/twofactor_totp.git
 
           - name: user_ldap
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/user_ldap.git
 
           - name: encryption
             mode: old
             branch: master
             sub_path: l10n
             package_manager: npm
-            url: https://github.com/owncloud/encryption.git
 
           - name: ocis
             mode: make
             branch: master
             sub_path: .
             package_manager: npm
-            url: https://github.com/owncloud/ocis.git
 
           - name: openidconnect
             mode: make
             branch: master
             sub_path: .
             package_manager: npm
-            url: https://github.com/owncloud/openidconnect.git
 
           - name: web
             mode: make
             branch: master
             sub_path: .
             package_manager: pnpm
-            url: https://github.com/owncloud/web.git
 
           - name: web-extensions
             mode: make
             branch: main
             sub_path: .
             package_manager: pnpm
-            url: https://github.com/owncloud/web-extensions.git
 
           - name: android
             mode: native
             branch: master
             sub_path: .
             package_manager: npm
-            url: https://github.com/owncloud/android.git
 
     steps:
-      - name: Wipe checkout
-        run: rm -rf '${{ matrix.name }}'
-
-      - name: Clone repository
-        run: git clone --branch '${{ matrix.branch }}' '${{ matrix.url }}' '${{ matrix.name }}'
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: owncloud/${{ matrix.name }}
+          ref: ${{ matrix.branch }}
+          path: ${{ matrix.name }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Create translation directory
         if: matrix.mode == 'old'

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -361,8 +361,8 @@ jobs:
         with:
           target_branch: ${{ matrix.branch }}
           commit_message: "[tx] updated from transifex"
-          commit_user_name: ownClouders
-          commit_user_email: devops@owncloud.com
-          files_pattern: ${{ matrix.name }}
-          empty_commit: false
+          name: ownClouders
+          email: devops@owncloud.com
+          files: ${{ matrix.name }}
+          empty: 0
           access_token: ${{ secrets.GIT_PUSH_PAT }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -269,8 +269,6 @@ jobs:
         env:
           GIT_PUSH_PAT: ${{ secrets.GIT_PUSH_PAT }}
         run: |
-          git config --global user.name "ownClouders"
-          git config --global user.email "devops@owncloud.com"
           git config --global --add safe.directory '*'
           git config --global url."https://x-access-token:${GIT_PUSH_PAT}@github.com/".insteadOf "https://github.com/"
 
@@ -364,19 +362,13 @@ jobs:
           find . -name "yo.*" -type f -print0 | xargs -r -0 git rm -f
           find . -name "ne.*" -type f -print0 | xargs -r -0 git rm -f
 
-      - name: Commit translations
-        run: |
-          cd '${{ matrix.name }}'
-          git add -A
-          git diff --staged --quiet || git commit -m "[tx] updated from transifex"
-
-      - name: Show commit
-        run: |
-          cd '${{ matrix.name }}'
-          git show -p
-
-      - name: Push translations
+      - name: Commit and push translations
         if: github.ref == 'refs/heads/master'
-        run: |
-          cd '${{ matrix.name }}'
-          git push origin '${{ matrix.branch }}'
+        uses: GuillaumeFalourd/git-commit-push@205c043bca2f932f7a48a28a8d619ba30eb84baf
+        with:
+          target_branch: ${{ matrix.branch }}
+          commit_message: "[tx] updated from transifex"
+          commit_user_name: ownClouders
+          commit_user_email: devops@owncloud.com
+          files_pattern: ${{ matrix.name }}
+          empty_commit: false

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,449 @@
+name: Translation Sync
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: owncloudci/transifex:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: core
+            mode: make
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/core.git
+            git: git@github.com:owncloud/core.git
+
+          - name: activity
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/activity.git
+            git: git@github.com:owncloud/activity.git
+
+          - name: announcementcenter
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/announcementcenter.git
+            git: git@github.com:owncloud/announcementcenter.git
+
+          - name: brute_force_protection
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/brute_force_protection.git
+            git: git@github.com:owncloud/brute_force_protection.git
+
+          - name: calendar
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/calendar.git
+            git: git@github.com:owncloud/calendar.git
+
+          - name: contacts
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/contacts.git
+            git: git@github.com:owncloud/contacts.git
+
+          - name: customgroups
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/customgroups.git
+            git: git@github.com:owncloud/customgroups.git
+
+          - name: diagnostics
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/diagnostics.git
+            git: git@github.com:owncloud/diagnostics.git
+
+          - name: drawio
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/drawio.git
+            git: git@github.com:owncloud/drawio.git
+
+          - name: external
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/external.git
+            git: git@github.com:owncloud/external.git
+
+          - name: files_antivirus
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/files_antivirus.git
+            git: git@github.com:owncloud/files_antivirus.git
+
+          - name: files_external_dropbox
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/files_external_dropbox.git
+            git: git@github.com:owncloud/files_external_dropbox.git
+
+          - name: files_external_ftp
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/files_external_ftp.git
+            git: git@github.com:owncloud/files_external_ftp.git
+
+          - name: files_paperhive
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/files_paperhive.git
+            git: git@github.com:owncloud/files_paperhive.git
+
+          - name: files_primary_s3
+            mode: make
+            branch: master
+            sub_path: .
+            package_manager: npm
+            url: https://github.com/owncloud/files_primary_s3.git
+            git: git@github.com:owncloud/files_primary_s3.git
+
+          - name: files_mediaviewer
+            mode: make
+            branch: master
+            sub_path: .
+            package_manager: npm
+            url: https://github.com/owncloud/files_mediaviewer.git
+            git: git@github.com:owncloud/files_mediaviewer.git
+
+          - name: files_texteditor
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/files_texteditor.git
+            git: git@github.com:owncloud/files_texteditor.git
+
+          - name: files_pdfviewer
+            mode: make
+            branch: master
+            sub_path: .
+            package_manager: npm
+            url: https://github.com/owncloud/files_pdfviewer.git
+            git: git@github.com:owncloud/files_pdfviewer.git
+
+          - name: firstrunwizard
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/firstrunwizard.git
+            git: git@github.com:owncloud/firstrunwizard.git
+
+          - name: guests
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/guests.git
+            git: git@github.com:owncloud/guests.git
+
+          - name: impersonate
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/impersonate.git
+            git: git@github.com:owncloud/impersonate.git
+
+          - name: notes
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/notes.git
+            git: git@github.com:owncloud/notes.git
+
+          - name: notifications
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/notifications.git
+            git: git@github.com:owncloud/notifications.git
+
+          - name: oauth2
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/oauth2.git
+            git: git@github.com:owncloud/oauth2.git
+
+          - name: password_policy
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/password_policy.git
+            git: git@github.com:owncloud/password_policy.git
+
+          - name: richdocuments
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/richdocuments.git
+            git: git@github.com:owncloud/richdocuments.git
+
+          - name: twofactor_backup_codes
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/twofactor_backup_codes.git
+            git: git@github.com:owncloud/twofactor_backup_codes.git
+
+          - name: twofactor_privacyidea
+            mode: old
+            branch: master
+            sub_path: twofactor_privacyidea/l10n
+            package_manager: npm
+            url: https://github.com/privacyidea/privacyidea-owncloud-app.git
+            git: git@github.com:privacyidea/privacyidea-owncloud-app.git
+
+          - name: twofactor_totp
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/twofactor_totp.git
+            git: git@github.com:owncloud/twofactor_totp.git
+
+          - name: user_ldap
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/user_ldap.git
+            git: git@github.com:owncloud/user_ldap.git
+
+          - name: encryption
+            mode: old
+            branch: master
+            sub_path: l10n
+            package_manager: npm
+            url: https://github.com/owncloud/encryption.git
+            git: git@github.com:owncloud/encryption.git
+
+          - name: ocis
+            mode: make
+            branch: master
+            sub_path: .
+            package_manager: npm
+            url: https://github.com/owncloud/ocis.git
+            git: git@github.com:owncloud/ocis.git
+
+          - name: openidconnect
+            mode: make
+            branch: master
+            sub_path: .
+            package_manager: npm
+            url: https://github.com/owncloud/openidconnect.git
+            git: git@github.com:owncloud/openidconnect.git
+
+          - name: web
+            mode: make
+            branch: master
+            sub_path: .
+            package_manager: pnpm
+            url: https://github.com/owncloud/web.git
+            git: git@github.com:owncloud/web.git
+
+          - name: web-extensions
+            mode: make
+            branch: main
+            sub_path: .
+            package_manager: pnpm
+            url: https://github.com/owncloud/web-extensions.git
+            git: git@github.com:owncloud/web-extensions.git
+
+          - name: android
+            mode: native
+            branch: master
+            sub_path: .
+            package_manager: npm
+            url: https://github.com/owncloud/android.git
+            git: git@github.com:owncloud/android.git
+
+    steps:
+      - name: Configure git
+        run: |
+          git config --global user.name "ownClouders"
+          git config --global user.email "devops@owncloud.com"
+          git config --global --add safe.directory '*'
+
+      - name: Wipe checkout
+        run: rm -rf '${{ matrix.name }}'
+
+      - name: Clone repository
+        run: git clone --branch '${{ matrix.branch }}' '${{ matrix.url }}' '${{ matrix.name }}'
+
+      - name: Create translation directory
+        if: matrix.mode == 'old'
+        run: mkdir -p '${{ matrix.name }}/${{ matrix.sub_path }}'
+
+      - name: Translation reader (make)
+        if: matrix.mode == 'make'
+        env:
+          NO_INSTALL: "true"
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          if [ '${{ matrix.package_manager }}' = 'pnpm' ]; then
+            npm install --silent --global --force "$(jq -r '.packageManager' < package.json)"
+            pnpm config set store-dir ./.pnpm-store
+            pnpm install
+          fi
+          make l10n-read
+
+      - name: Translation reader (old)
+        if: matrix.mode == 'old'
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          l10n '${{ matrix.name }}' read
+
+      - name: Translation push (make)
+        if: matrix.mode == 'make' && github.ref == 'refs/heads/master'
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          make l10n-push
+
+      - name: Translation push (old)
+        if: matrix.mode == 'old' && github.ref == 'refs/heads/master'
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          tx push -s --skip
+
+      - name: Translation pull (make)
+        if: matrix.mode == 'make'
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          make l10n-pull
+
+      - name: Translation pull (old/native)
+        if: matrix.mode != 'make'
+        env:
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          tx pull -a --skip --minimum-perc=75 -f
+
+      - name: Translation writer (make)
+        if: matrix.mode == 'make'
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          make l10n-write
+
+      - name: Translation writer (old)
+        if: matrix.mode == 'old'
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          l10n '${{ matrix.name }}' write
+
+      - name: Translation cleanup (make)
+        if: matrix.mode == 'make'
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          make l10n-clean
+
+      - name: Translation cleanup (old)
+        if: matrix.mode == 'old'
+        run: |
+          cd '${{ matrix.name }}/${{ matrix.sub_path }}'
+          find . -name "*.po" -type f -delete
+          find . -name "*.pot" -type f -delete
+          find . -name "or_IN.*" -type f -print0 | xargs -r -0 git rm -f
+          find . -name "uz.*" -type f -print0 | xargs -r -0 git rm -f
+          find . -name "yo.*" -type f -print0 | xargs -r -0 git rm -f
+          find . -name "ne.*" -type f -print0 | xargs -r -0 git rm -f
+
+      - name: Commit translations
+        run: |
+          cd '${{ matrix.name }}'
+          git add -A
+          git diff --staged --quiet || git commit -m "[tx] updated from transifex"
+
+      - name: Show commit
+        run: |
+          cd '${{ matrix.name }}'
+          git show -p
+
+      - name: Setup SSH key
+        if: github.ref == 'refs/heads/master'
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.GIT_PUSH_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+      - name: Push translations
+        if: github.ref == 'refs/heads/master'
+        env:
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no
+        run: |
+          cd '${{ matrix.name }}'
+          git remote set-url origin '${{ matrix.git }}'
+          git push origin '${{ matrix.branch }}'
+
+  notification:
+    name: notification
+    runs-on: ubuntu-latest
+    needs: sync
+    if: always() && github.ref == 'refs/heads/master' && (needs.sync.result == 'failure' || (needs.sync.result == 'success' && github.event_name == 'schedule'))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Send Matrix notification
+        env:
+          MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
+          JOB_STATUS: ${{ needs.sync.result }}
+        run: bash config/github/notification.sh

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -231,7 +231,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: owncloud/${{ matrix.name }}
           ref: ${{ matrix.branch }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+This repository orchestrates automated Transifex translation synchronization across 36 ownCloud repositories using GitHub Actions. There is no build system for this repo itself — it is a configuration-only repository.
+
+## Key Files
+
+- **`.github/workflows/translations.yml`** — The active CI pipeline. Matrix job (one entry per managed repo) plus a notification job.
+- **`.drone.star`** — Legacy Drone CI configuration (superseded by the GitHub Actions workflow above).
+- **`config/github/notification.sh`** — Sends Matrix/Element chat notifications on build completion (used by the notification job).
+- **`config/drone/notification.sh`** — Legacy Drone notification script.
+- **`docs/sync_issues.md`** — Troubleshooting guide for translation string issues (unescaped characters, etc.).
+- **`docs/migrate.md`** — Guide for migrating resources between Transifex projects using the `tx` CLI.
+
+## Architecture
+
+The pipeline system uses a matrix job model:
+
+- `.github/workflows/translations.yml` defines a `sync` job with a matrix of all managed repositories running in parallel, followed by a `notification` job that depends on `sync`.
+- All steps run inside the `owncloudci/transifex:latest` Docker container (via `container:` at the job level).
+- The matrix encodes all repo-specific configuration: name, mode, branch, sub_path, package_manager, HTTPS clone URL, SSH push URL.
+
+### Translation Modes
+
+Each repository is assigned one of three modes (set via the `mode` field in the matrix):
+
+| Mode | Description |
+|------|-------------|
+| `old` | Legacy `l10n` tool + `tx` CLI. Steps: `l10n write` → `tx push` → `tx pull` → `l10n read` |
+| `make` | Modern Makefile targets: `l10n-read`, `l10n-push`, `l10n-pull`, `l10n-write`, `l10n-clean` |
+| `native` | Android apps — special handling |
+
+### Pipeline Steps (per repo)
+
+1. Wipe checkout (clean slate)
+2. Clone repo via HTTPS
+3. (old mode only) Create translation directory
+4. Reader — extract translatable strings
+5. Push — send new strings to Transifex
+6. Pull — fetch translations from Transifex
+7. Writer — write translations to repo files
+8. Cleanup — remove temp `.po`/`.pot` files
+9. Commit — commit with standard message
+10. Show commit — log diff
+11. Switch remote — swap to SSH for push
+12. Push commit — push to repository
+
+Steps 5 (push) and 11–12 (SSH push) only run when `github.ref == 'refs/heads/master'`.
+
+### GitHub Actions Secrets
+
+Three secrets must be configured in the repository settings:
+
+| Secret | Purpose |
+|--------|---------|
+| `TX_TOKEN` | Transifex API token |
+| `GIT_PUSH_SSH_KEY` | SSH private key for pushing commits back to repos |
+| `MATRIX_TOKEN` | Matrix/Element bot token for notifications |
+
+## Local Testing
+
+To manually test translation sync for a specific repo (e.g., `guests`):
+
+```bash
+git clone git@github.com:owncloud/guests /path/to/repo
+cd /path/to/repo
+export TX_TOKEN=<your_transifex_token>
+tx pull -a --skip --minimum-perc=75 -f
+```
+
+For **old mode** repos using the legacy l10n tool:
+
+```bash
+docker run -ti -v $(pwd):/mnt -w /mnt --entrypoint=/bin/bash \
+  owncloudci/transifex:latest -c "cd l10n; l10n 'guests' write"
+```
+
+To trigger the sync manually, use the **Actions → Translation Sync → Run workflow** button in the GitHub UI, or via the CLI:
+
+```bash
+gh workflow run translations.yml
+```
+
+## Adding a New Repository
+
+Add a new entry under `matrix.include` in `.github/workflows/translations.yml`. Copy an existing entry of the same mode (old/make) and update `name`, `url`, `git`, `branch`, and `sub_path` as needed. The `sub_path` is `l10n` for old mode and `.` for make mode unless the repo uses a non-standard layout (see `twofactor_privacyidea` for an example).

--- a/config/github/notification.sh
+++ b/config/github/notification.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+
+COMMIT_SHA_SHORT=${GITHUB_SHA:0:8}
+BUILD_STATUS="✅ Success"
+ROOMID="!rnWsCVUmDHDJbiSPMM:matrix.org"
+
+# helper functions
+log_error() {
+  echo -e "\e[31m$1\e[0m"
+}
+
+log_info() {
+  echo -e "\e[37m$1\e[0m"
+}
+
+log_success() {
+  echo -e "\e[32m$1\e[0m"
+}
+
+# Determine build source: nightly, tag or branch
+if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+  BUILD_SOURCE="nightly-${GITHUB_REF_NAME}"
+elif [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+  BUILD_SOURCE="tag ${GITHUB_REF_NAME}"
+else
+  BUILD_SOURCE="${GITHUB_REF_NAME}"
+fi
+
+if [[ "$JOB_STATUS" == "failure" ]]; then
+  BUILD_STATUS="❌️ Failure"
+fi
+
+BUILD_LINK="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+COMMIT_AUTHOR=$(git log -1 --pretty=format:'%an' 2>/dev/null || echo "unknown")
+
+message_html='<b>'$BUILD_STATUS'</b> <a href="'${BUILD_LINK}'">'${GITHUB_REPOSITORY}'#'$COMMIT_SHA_SHORT'</a> ('${BUILD_SOURCE}') by <b>'${COMMIT_AUTHOR}'</b>'
+message_html=$(echo "$message_html" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+
+log_info "Sending report to the element chat...."
+
+response=$(curl -s -o /dev/null -X PUT -w "%{http_code}" "https://matrix.org/_matrix/client/v3/rooms/${ROOMID}/send/m.room.message/$(date +%s)" \
+  -H "Authorization: Bearer ${MATRIX_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "msgtype": "m.text",
+    "body": "'"$message_html"'",
+    "format": "org.matrix.custom.html",
+    "formatted_body": "'"$message_html"'"
+  }')
+
+if [[ "$response" != "200" ]]; then
+  log_error "❌ Error: Failed to send notification to element. Expected status code 200, but got $response."
+  exit 1
+fi
+
+log_success "✅ Notification successfully sent to Element chat (ownCloud Infinite Scale Alerts)"


### PR DESCRIPTION
## Summary

Replaces the Drone CI pipeline (`.drone.star`) with GitHub Actions.

- Adds `.github/workflows/translations.yml` — matrix job with one entry per managed repo (35 total) running in parallel inside `owncloudci/transifex:latest`, triggered on schedule (nightly), `workflow_dispatch`, push to `master`, and pull requests (temporary, for testing)
- Uses `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) with `persist-credentials: false` and `fetch-depth: 0` per the [known-issue recommendation](https://github.com/GuillaumeFalourd/git-commit-push?tab=readme-ov-file#known-issue)
- Uses `GuillaumeFalourd/git-commit-push@205c043bca2f932f7a48a28a8d619ba30eb84baf` for commit and push, authenticated via PAT (`access_token`)
- Drops `twofactor_privacyidea` (external org repo) and Matrix chat notifications (superseded by GitHub's built-in workflow notifications)
- Adds `.github/workflows/lint-pr-title.yml` for semantic PR title linting

## Required secret

| Secret | Purpose |
|--------|---------|
| `TX_TOKEN` | Transifex API token |
| `GIT_PUSH_PAT` | PAT with `Contents: Write` on all target repos, used for pushing translation commits back |

## Behavioural equivalence

| Drone | GitHub Actions |
|-------|---------------|
| Parallel per-repo pipelines | `strategy.matrix.include` with `fail-fast: false` |
| `whenPush()` guard (master only) | `if: github.ref == 'refs/heads/master'` on the commit/push step |
| `empty_commit: false` | `empty: 0` on `git-commit-push` |
| SSH key push | PAT over HTTPS via `access_token` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)